### PR TITLE
Ignore compiler-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ slprj/
 
 # Session info
 octave-workspace
+
+# Compiler-generated object files
+*.o
+*.o-*
+*.obj
+*.a


### PR DESCRIPTION
All in the title; I simply added a few lines in `.gitignore` to ignore compiler-generated files.

Ignoring these object files should prevent future issues for contributors who may otherwise accidentally include them in PRs.

It may also be worth including a note for contributors to run:

    git update-index --assume-unchanged util/lbfgsb/Makefile

again to avoid including local changes to that file in PRs.